### PR TITLE
feat: implement timeouts for all methods

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -39,3 +39,5 @@ Exceptions
 ----------
 
 .. autoexception:: UptimeKumaException
+
+.. autoexception:: Timeout

--- a/uptime_kuma_api/__init__.py
+++ b/uptime_kuma_api/__init__.py
@@ -6,6 +6,6 @@ from .proxy_protocol import ProxyProtocol
 from .incident_style import IncidentStyle
 from .docker_type import DockerType
 from .maintenance_strategy import MaintenanceStrategy
-from .exceptions import UptimeKumaException
+from .exceptions import UptimeKumaException, Timeout
 from .event import Event
 from .api import UptimeKumaApi

--- a/uptime_kuma_api/exceptions.py
+++ b/uptime_kuma_api/exceptions.py
@@ -2,4 +2,9 @@ class UptimeKumaException(Exception):
     """
     There was an exception that occurred while communicating with Uptime Kuma.
     """
-    pass
+
+
+class Timeout(UptimeKumaException):
+    """
+    A timeout has occurred while communicating with Uptime Kuma.
+    """


### PR DESCRIPTION
The `wait_timeout` parameter was removed and a `timeout` parameter was added instead.
The new `timeout` parameter is used for several types of timeouts. It specifies how many seconds the client should wait for the connection, an expected event or a server response. The default timeout is 10 seconds.