### PR TITLE
support new showCertificateExpiry in status page JSON

### DIFF
--- a/uptime_kuma_api/api.py
+++ b/uptime_kuma_api/api.py
@@ -926,6 +926,7 @@ class UptimeKumaApi(object):
             customCSS: str = "",
             footerText: str = None,
             showPoweredBy: bool = True,
+            showCertificateExpiry: bool = False,
 
             icon: str = "/icon.svg",
             publicGroupList: list = None


### PR DESCRIPTION
With latest uptime kuma (v1.23.0), we get this error:

```
TypeError: _build_status_page_data() got an unexpected keyword argument 'showCertificateExpiry'
```

There are a lot more changes of course, but this is the most obvious one that breaks the API, so hopefully this is enough to make it work again even if it doesn't support all other changes. Marked as draft for now as we haven't tested it yet.