### PR TITLE
fix type for notificationIDList in _build_monitor_data()

### DIFF
--- a/uptime_kuma_api/api.py
+++ b/uptime_kuma_api/api.py
@@ -792,7 +792,7 @@ class UptimeKumaApi(object):
             accepted_statuscodes = ["200-299"]
 
         if notificationIDList is None:
-            notificationIDList = {}
+            notificationIDList = []
 
         data = {
             "type": type,


### PR DESCRIPTION
The type here is incorrect. In `_build_monitor_data()`, the `notificationIDList` parameter is a `list`, which then gets converted to a `dict` in `_convert_monitor_input()`.

The wrong type here doesn't actually affect anything as it is an empty `dict` and thus never processed in `_convert_monitor_input()`, as an empty `list` would have been as well.

```py
    dict_notification_ids = {}
    if kwargs["notificationIDList"]:
        for notification_id in kwargs["notificationIDList"]:
            dict_notification_ids[notification_id] = True
    kwargs["notificationIDList"] = dict_notification_ids
```

But it's still technically the wrong type in that part of the code, and changing other parts of the code could result in that causing a bug at some point.

NB: I haven't tested this change yet.