### PR TITLE
Update api.py - call out API key usage specifically

### DIFF
--- a/uptime_kuma_api/api.py
+++ b/uptime_kuma_api/api.py
@@ -2995,6 +2995,9 @@ class UptimeKumaApi(object):
 
         If username and password is not provided, auto login is performed if disableAuth is enabled.
 
+        Note that the API Key configured in the Uptime Kuma UI is only for authentication for integration with Prometheus. It
+        cannot be used for authentication to this API.
+
         :param str, optional username: Username. Must be None if disableAuth is enabled., defaults to None
         :param str, optional password: Password. Must be None if disableAuth is enabled., defaults to None
         :param str, optional token: 2FA Token. Required if 2FA is enabled., defaults to ""


### PR DESCRIPTION
You can find docs/issues filed about this, but it's very unclear until you do so that the API Key in the Uptime Kuma web UI is not usable in any way for API calls other than prometheus.