### PR TITLE
Update docstrings.py - Fixed param type (parent)

### DIFF
--- a/uptime_kuma_api/docstrings.py
+++ b/uptime_kuma_api/docstrings.py
@@ -18,7 +18,7 @@ def monitor_docstring(mode) -> str:
     return f"""
         :param MonitorType{", optional" if mode == "edit" else ""} type: Monitor Type
         :param str{", optional" if mode == "edit" else ""} name: Friendly Name
-        :param str, optional parent: Id of the monitor group, defaults to None
+        :param int, optional parent: Id of the monitor group, defaults to None
         :param str, optional description: Description, defaults to None
         :param int, optional interval: Heartbeat Interval, defaults to 60
         :param int, optional retryInterval: Retry every X seconds, defaults to 60


### PR DESCRIPTION
'parent' option in monitor_docstring definition incorrectly listed as string. Integer required. Does not support a monitor friendly name.