### PR TITLE
Fixed datatype for smtpSecure property to bool

### DIFF
--- a/uptime_kuma_api/notification_providers.py
+++ b/uptime_kuma_api/notification_providers.py
@@ -394,7 +394,7 @@ notification_provider_options = {
     NotificationType.SMTP: dict(
         smtpHost=dict(type="str", required=True),
         smtpPort=dict(type="int", required=True),
-        smtpSecure=dict(type="str", required=False),
+        smtpSecure=dict(type="bool", required=False),
         smtpIgnoreTLSError=dict(type="bool", required=False),
         smtpDkimDomain=dict(type="str", required=False),
         smtpDkimKeySelector=dict(type="str", required=False),


### PR DESCRIPTION
We were having issues when using the uptime-kuma-api to configure a notification with type "smtp".
After some troubleshooting and viewing entries in the kuma.db we had pinned down the issue due to a wrong datatype of the smtpSecure property in the notification provider.

This PR fixes this issue - we have tested this modification in our environment successfully.