### PR TITLE
Fix `save_status_page` for v2.0.2 by removing `autoRefreshInterval`

### DIFF
--- a/uptime_kuma_api/api.py
+++ b/uptime_kuma_api/api.py
@@ -2130,6 +2130,7 @@ class UptimeKumaApi(object):
         status_page = self.get_status_page(slug)
         status_page.pop("incident")
         status_page.pop("maintenanceList")
+        status_page.pop("autoRefreshInterval")
         status_page.update(kwargs)
         data = self._build_status_page_data(**status_page)
         r = self._call('saveStatusPage', data)


### PR DESCRIPTION
As of Uptime Kuma v2.0.2 (likely introduced in v2.0.0), `get_status_page` includes data for `autoRefreshInterval`.

``` python
>>> api.get_status_page("test")
{'id': 1, 'slug': 'test', 'title': 'Test', 'description': None, 'icon': '/icon.svg', 'theme': 'auto', 'autoRefreshInterval': 300, 'published': True, 'showTags': False, 'domainNameList': [], 'customCSS': None, 'footerText': None, 'showPoweredBy': True, 'googleAnalyticsId': None, 'showCertificateExpiry': False, 'incident': None, 'publicGroupList': [], 'maintenanceList': []}
```

This change throws an error when sending this data through to `_build_status_page_data`.

``` python
>>> api.save_status_page(slug="test",title="Test")
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    api.save_status_page(slug="test",title="Test")
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/.../.local/lib/python3.13/site-packages/uptime_kuma_api/api.py", line 2134, in save_status_page
    data = self._build_status_page_data(**status_page)
TypeError: UptimeKumaApi._build_status_page_data() got an unexpected keyword argument 'autoRefreshInterval'
```

This update removes `autoRefreshInterval` from the data before sending it to `_build_status_page_data`.