### PR TITLE
Add conditions option to DNS monitors

### DIFF
--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -190,7 +190,14 @@ class TestMonitor(UptimeKumaTestCase):
             "hostname": "127.0.0.1",
             "port": 8888,
             "dns_resolve_server": "1.1.1.1",
-            "dns_resolve_type": "A"
+            "dns_resolve_type": "A",
+            "conditions": [{
+                "type": "expression",
+                "variable": "record",
+                "operator": "equals",
+                "value": "127.0.0.1",
+                "andOr": "and"
+            }],
         }
         self.do_test_monitor_type(expected_monitor)
 

--- a/uptime_kuma_api/api.py
+++ b/uptime_kuma_api/api.py
@@ -751,7 +751,7 @@ class UptimeKumaApi(object):
             # DNS
             dns_resolve_server: str = "1.1.1.1",
             dns_resolve_type: str = "A",
-            conditions: list = [],
+            conditions: list = None,
 
             # MQTT
             mqttUsername: str = "",
@@ -915,7 +915,7 @@ class UptimeKumaApi(object):
         data.update({
             "dns_resolve_server": dns_resolve_server,
             "dns_resolve_type": dns_resolve_type,
-            "conditions": conditions,
+            "conditions": conditions if conditions else [],
         })
 
         # MQTT

--- a/uptime_kuma_api/api.py
+++ b/uptime_kuma_api/api.py
@@ -751,6 +751,7 @@ class UptimeKumaApi(object):
             # DNS
             dns_resolve_server: str = "1.1.1.1",
             dns_resolve_type: str = "A",
+            conditions: list = [],
 
             # MQTT
             mqttUsername: str = "",
@@ -914,6 +915,7 @@ class UptimeKumaApi(object):
         data.update({
             "dns_resolve_server": dns_resolve_server,
             "dns_resolve_type": dns_resolve_type,
+            "conditions": conditions,
         })
 
         # MQTT
@@ -1118,6 +1120,7 @@ class UptimeKumaApi(object):
                     'dns_last_result': None,
                     'dns_resolve_server': '1.1.1.1',
                     'dns_resolve_type': 'A',
+                    'conditions': [],
                     'docker_container': None,
                     'docker_host': None,
                     'expiryNotification': False,
@@ -1211,6 +1214,7 @@ class UptimeKumaApi(object):
                 'dns_last_result': None,
                 'dns_resolve_server': '1.1.1.1',
                 'dns_resolve_type': 'A',
+                'conditions': [],
                 'docker_container': None,
                 'docker_host': None,
                 'expectedValue': None,

--- a/uptime_kuma_api/docstrings.py
+++ b/uptime_kuma_api/docstrings.py
@@ -68,6 +68,7 @@ def monitor_docstring(mode) -> str:
             - "SOA"
             - "SRV"
             - "TXT"
+        :param list, optional conditions: One or more groups of DNS record conditions which will be validated during uptime tests, defaults to ``[]``.
         :param str, optional mqttUsername: MQTT Username, defaults to None
         :param str, optional mqttPassword: MQTT Password, defaults to None
         :param str, optional mqttTopic: MQTT Topic, defaults to None


### PR DESCRIPTION
The `conditions` option is used for DNS monitor types to validate the data of records during an uptime check. This update adds the ability to set that value when creating or editing monitors.

An example of adding a new DNS monitor with this property is as follows:

``` python
api.add_monitor(
    type=MonitorType.DNS,
    name="Test",
    hostname="localhost",
    dns_resolve_type="A",
    conditions=[
        {
            "type": "expression",
            "variable": "record",
            "operator": "equals",
            "value": "127.0.0.1",
            "andOr": "and",
        },
    ],
)
```

_Note: I'm not completely familiar with the formatting of this data nor does this update include any validation of the `conditions` value._