### PR TITLE
fix: fix docstring about pagerduty where mandatory was inverse with o…

### DIFF
--- a/uptime_kuma_api/docstrings.py
+++ b/uptime_kuma_api/docstrings.py
@@ -200,14 +200,14 @@ def notification_docstring(mode) -> str:
         :param str, optional recieverId: Notification option for ``type`` :attr:`~.NotificationType.ONEBOT`.
         :param int opsgeniePriority: Notification option for ``type`` :attr:`~.NotificationType.OPSGENIE`. Priority. Available values are numbers between ``1`` and ``5``.
         :param str, optional opsgenieRegion: Notification option for ``type`` :attr:`~.NotificationType.OPSGENIE`. Region. Available values are:
-            
+ 
             - ``us``: US (Default)
             - ``eu``: EU
         :param str, optional opsgenieApiKey: Notification option for ``type`` :attr:`~.NotificationType.OPSGENIE`. API Key.
-        :param str pagerdutyAutoResolve: Notification option for ``type`` :attr:`~.NotificationType.PAGERDUTY`.
-        :param str pagerdutyIntegrationUrl: Notification option for ``type`` :attr:`~.NotificationType.PAGERDUTY`.
-        :param str pagerdutyPriority: Notification option for ``type`` :attr:`~.NotificationType.PAGERDUTY`.
-        :param str, optional pagerdutyIntegrationKey: Notification option for ``type`` :attr:`~.NotificationType.PAGERDUTY`.
+        :param str, optional pagerdutyAutoResolve: Notification option for ``type`` :attr:`~.NotificationType.PAGERDUTY`.
+        :param str, optional pagerdutyIntegrationUrl: Notification option for ``type`` :attr:`~.NotificationType.PAGERDUTY`.
+        :param str, optional pagerdutyPriority: Notification option for ``type`` :attr:`~.NotificationType.PAGERDUTY`.
+        :param str, pagerdutyIntegrationKey: Notification option for ``type`` :attr:`~.NotificationType.PAGERDUTY`.
         :param str pagertreeAutoResolve: Notification option for ``type`` :attr:`~.NotificationType.PAGERTREE`. 
         
             Available values are:


### PR DESCRIPTION
In docstring https://uptime-kuma-api.readthedocs.io/en/latest/api.html#uptime_kuma_api.NotificationType.PAGERDUTY

Pagerduty arguments are inversed. Optional is mandatory and mandatory is optional. 

<img width="679" height="389" alt="image" src="https://github.com/user-attachments/assets/6339c39b-615d-45ae-a3a6-3d31b06102db" />
